### PR TITLE
DEXW-2865: Create account fix for empty Local Storage

### DIFF
--- a/src/iframe-entry/services/storage.ts
+++ b/src/iframe-entry/services/storage.ts
@@ -12,7 +12,7 @@ class StorageService {
 
     private static readonly parser: TParser = {
         termsAccepted: (accepted) => accepted === 'true',
-        multiAccountUsers: (data) => JSON.parse(data || '') || {},
+        multiAccountUsers: (data) => JSON.parse(data || '{}') || {},
     };
 
     public update(storage: Partial<IStorage>): void {


### PR DESCRIPTION
JSON.parse() не принимает пустую строку.