### PR TITLE
Remove Safari Check

### DIFF
--- a/packages/provider-web/src/ProviderWeb.ts
+++ b/packages/provider-web/src/ProviderWeb.ts
@@ -83,14 +83,6 @@ export class ProviderWeb implements Provider {
 
         const iframe = this._transport.get();
 
-        if (isSafari()) {
-            const win = iframe.contentWindow?.open(this._clientUrl);
-
-            if (!win) {
-                throw new Error('Window was blocked');
-            }
-        }
-
         iframe.src = this._clientUrl;
 
         return this._transport.dialog((bus) =>


### PR DESCRIPTION
This provider is not working on Safari when the popup window is blocked.
So I removed Safari check code on login method so that it can work on Safari also.